### PR TITLE
feat: enable to call by :Telescope ctags_online

### DIFF
--- a/lua/telescope/_extensions/ctags_outline.lua
+++ b/lua/telescope/_extensions/ctags_outline.lua
@@ -163,5 +163,5 @@ end
 
 return telescope.register_extension({
     setup = ctags_setup,
-    exports = { outline = outline },
+    exports = { ctags_outline = outline, outline = outline },
 })


### PR DESCRIPTION
With this patch, we can call this plugin with simply `:Telescope ctags_outline`. The current logic needs `:Telescope ctags_outline outline`.